### PR TITLE
chore: host airflow in tailnet

### DIFF
--- a/airflow/ingress.yaml
+++ b/airflow/ingress.yaml
@@ -3,15 +3,13 @@ kind: Ingress
 metadata:
   name: airflow-ingress
   namespace: causality
-  annotations:
-    cert-manager.io/cluster-issuer: lets-encrypt
 spec:
+  ingressClassName: tailscale
   tls:
     - hosts:
-        - airflow.causality.africa
-      secretName: airflow-tls
+        - airflow
   rules:
-    - host: airflow.causality.africa
+    - host: airflow
       http:
         paths:
           - path: /

--- a/base/issuer.yaml
+++ b/base/issuer.yaml
@@ -12,4 +12,4 @@ spec:
     solvers:
       - http01:
           ingress:
-            class: traefik
+            class: nginx


### PR DESCRIPTION
Airflow shouldn't be exposed to the public web so now it's inside a private tailscale network.